### PR TITLE
Exclude abstract classes from self discover

### DIFF
--- a/src/yandil/discovery/module_discovery.py
+++ b/src/yandil/discovery/module_discovery.py
@@ -2,7 +2,7 @@ import pkgutil
 from dataclasses import dataclass
 from importlib.machinery import FileFinder
 from os.path import join
-from typing import Iterator, Optional, Set
+from typing import Iterable, Optional, Set
 
 
 @dataclass(frozen=True)
@@ -11,7 +11,7 @@ class ModuleData:
     module_path: str
 
 
-def discover_modules(base_path: str, exclude_modules: Optional[Set[str]] = None) -> Iterator[ModuleData]:
+def discover_modules(base_path: str, exclude_modules: Optional[Set[str]] = None) -> Iterable[ModuleData]:
     if exclude_modules is None:
         exclude_modules = set()
 

--- a/src/yandil/loaders/self_discover_dependency_loader.py
+++ b/src/yandil/loaders/self_discover_dependency_loader.py
@@ -4,6 +4,7 @@ from yandil.container import Container, default_container
 from yandil.discovery.class_discovery import (
     ClassData,
     discover_classes_from_module,
+    exclude_abstract_classes,
     exclude_classes_without_public_methods,
     exclude_dataclasses,
     transform_class_nodes_to_class_data,
@@ -47,7 +48,7 @@ class SelfDiscoverDependencyLoader:
         should_exclude_classes_without_public_methods: bool,
         should_exclude_dataclasses: bool,
     ) -> Iterable[ClassData]:
-        iterable = discover_classes_from_module(module_file_path)
+        iterable = exclude_abstract_classes(discover_classes_from_module(module_file_path))
         if should_exclude_classes_without_public_methods:
             iterable = exclude_classes_without_public_methods(iterable)
         if should_exclude_dataclasses:

--- a/tests/integration/discovery/test_class_discovery.py
+++ b/tests/integration/discovery/test_class_discovery.py
@@ -5,6 +5,7 @@ from yandil.discovery.class_discovery import (
     class_defines_public_methods,
     class_has_any_decorator,
     discover_classes_from_module,
+    exclude_abstract_classes,
     exclude_classes_without_decorators,
     exclude_classes_without_public_methods,
     exclude_dataclasses,
@@ -106,3 +107,11 @@ class TestClassDiscovery(TestCase):
         class_excluding_ones_without_decorators = list(exclude_classes_without_decorators(discovered_classes, {"test"}))
 
         self.assertEqual(0, len(class_excluding_ones_without_decorators))
+
+    def test_exclude_abstract_classes(self):
+        module_file_path = join(self.__DISCOVERY_BASE_PATH, "abstract_class.py")
+        discovered_classes = discover_classes_from_module(module_file_path)
+
+        classes_excluding_abstract_classes = list(exclude_abstract_classes(discovered_classes))
+
+        self.assertEqual(0, len(classes_excluding_abstract_classes))

--- a/tests/integration/discovery/test_module_discovery.py
+++ b/tests/integration/discovery/test_module_discovery.py
@@ -10,7 +10,7 @@ class TestModuleDiscovery(TestCase):
     def test_discover_modules_from_path(self):
         discovered_modules = list(discover_modules(self.__DISCOVERY_BASE_PATH))
 
-        self.assertEqual(6, len(discovered_modules))
+        self.assertEqual(7, len(discovered_modules))
         discovered_module_names = [module.module_name for module in discovered_modules]
         expected_module_names = [
             "class_with_public_methods",
@@ -19,6 +19,7 @@ class TestModuleDiscovery(TestCase):
             "dependency_class",
             "class_without_public_methods",
             "declarative_dependency_class",
+            "abstract_class",
         ]
         self.assertCountEqual(expected_module_names, discovered_module_names)
 
@@ -27,7 +28,7 @@ class TestModuleDiscovery(TestCase):
 
         discovered_modules = list(discover_modules(self.__DISCOVERY_BASE_PATH, excluded_modules))
 
-        self.assertEqual(5, len(discovered_modules))
+        self.assertEqual(6, len(discovered_modules))
         discovered_module_names = [module.module_name for module in discovered_modules]
         expected_module_names = [
             "another_class_with_public_methods",
@@ -35,5 +36,6 @@ class TestModuleDiscovery(TestCase):
             "dependency_class",
             "class_without_public_methods",
             "declarative_dependency_class",
+            "abstract_class",
         ]
         self.assertCountEqual(expected_module_names, discovered_module_names)

--- a/tests/integration/resources/abstract_class_dependencies_classes.py
+++ b/tests/integration/resources/abstract_class_dependencies_classes.py
@@ -1,16 +1,20 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 
 
 class AbstractBaseClass(ABC):
-    pass
+    @abstractmethod
+    def method(self):
+        pass
 
 
 class AbstractBaseClassFirstChildren(AbstractBaseClass):
-    pass
+    def method(self):
+        pass
 
 
 class AbstractBaseClassSecondChildren(AbstractBaseClass):
-    pass
+    def method(self):
+        pass
 
 
 class ClassWithAbstractClassDependencies:

--- a/tests/integration/resources/dependency_discovery_tests_module/abstract_class.py
+++ b/tests/integration/resources/dependency_discovery_tests_module/abstract_class.py
@@ -1,0 +1,7 @@
+from abc import ABC, abstractmethod
+
+
+class AbstractClass(ABC):
+    @abstractmethod
+    def public_abstract_method(self):
+        pass


### PR DESCRIPTION
This fixes the issue when using the SelfDiscoverDependencyLoader with codebases containing abstract classes